### PR TITLE
Adicionar suporte ao nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1629284811,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c5d161cc0af116a2e17f54316f0bf43f0819785c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1629271619,
+        "narHash": "sha256-by9D3OkEKk4rOzJIMbC0uP2wP3Bt81auP5xmbmPg2a8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7bbca9877caed472c6b5866ea09302cfcdce3dbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-21.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Joguinho de forca";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+      name = "forca";
+    in rec {
+
+      packages.${name} = pkgs.stdenv.mkDerivation {
+        pname = name;
+        version = "1.0";
+        src = ./.;
+        installPhase = ''
+          mkdir -p $out/bin
+          mv build/${name} $out/bin
+        '';
+      };
+      defaultPackage = packages.${name};
+
+      apps.${name} = {
+        type = "app";
+        program = "${packages.${name}}/bin/${name}";
+      };
+      defaultApp = apps.${name};
+
+      devShell =
+        pkgs.mkShell { buildInputs = with pkgs; [ make gcc valgrind gdb ]; };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,6 @@
       defaultApp = apps.${name};
 
       devShell =
-        pkgs.mkShell { buildInputs = with pkgs; [ make gcc valgrind gdb ]; };
+        pkgs.mkShell { buildInputs = with pkgs; [ gnumake gcc valgrind gdb ]; };
     });
 }


### PR DESCRIPTION
Esse PR adiciona uma `flake.nix` e sua respectiva `flake.lock`. Que permitem usar `nix` para gerir o projeto.